### PR TITLE
Allow uppercase characters in blueprint search

### DIFF
--- a/Assets/Editor/Inspector/BlueprintTypesWindow.cs
+++ b/Assets/Editor/Inspector/BlueprintTypesWindow.cs
@@ -42,7 +42,7 @@ namespace OwlcatModification.Editor.Inspector
 				
 				using (new EditorGUILayout.VerticalScope())
 				{
-					string[] words = m_SearchString.Split(' ');
+					string[] words = m_SearchString.ToLowerInvariant().Split(' ');
 					
 					foreach (var t in BlueprintTypesCache.Types)
 					{

--- a/Assets/Editor/Inspector/CreateBlueprintWindow.cs
+++ b/Assets/Editor/Inspector/CreateBlueprintWindow.cs
@@ -103,7 +103,7 @@ namespace OwlcatModification.Editor.Inspector
 				
 				using (new EditorGUILayout.VerticalScope())
 				{
-					string[] words = m_SearchString.Split(' ');
+					string[] words = m_SearchString.ToLowerInvariant().Split(' ');
 					
 					foreach (var t in BlueprintTypesCache.Types)
 					{


### PR DESCRIPTION
Searching compares user input and the ToLowerInvariant() blueprint type name.

Add ToLowerInvariant() calls on user input to support uppercase characters.